### PR TITLE
fix: do not get videos

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ client.on("messageCreate", async (msg) => {
     .join("\n")
     .replace(/https:\/\/t.co\/\w+$/, "");
   const images = msg.embeds
-    .flatMap((e) => [e.thumbnail, e.image, e.video])
+    .flatMap((e) => [e.thumbnail, e.image])
     .filter((img) => img !== null)
     .map((img) => img.url);
 


### PR DESCRIPTION
2|reader   | TypeError: Cannot read properties of undefined (reading 'url')
2|reader   |     at Embed.get video [as video] (/root/discord-embeds-reader-bot/node_modules/discord.js/src/structures/Embed.js:118:28)
2|reader   |     at /root/discord-embeds-reader-bot/src/index.ts:34:46
2|reader   |     at Array.flatMap (<anonymous>)
2|reader   |     at /root/discord-embeds-reader-bot/src/index.ts:34:6
2|reader   |     at step (/root/discord-embeds-reader-bot/dist/index.js:33:23)
2|reader   |     at Object.next (/root/discord-embeds-reader-bot/dist/index.js:14:53)
2|reader   |     at fulfilled (/root/discord-embeds-reader-bot/dist/index.js:5:58)